### PR TITLE
Rename `blocks_split` to `split_blocks`

### DIFF
--- a/kenjutsu/kenjutsu.py
+++ b/kenjutsu/kenjutsu.py
@@ -379,7 +379,7 @@ def len_slices(slices, lengths=None):
     return(lens)
 
 
-def blocks_split(space_shape, block_shape, block_halo=None):
+def split_blocks(space_shape, block_shape, block_halo=None):
     """
         Return a list of slicings to cut each block out of an array or other.
 
@@ -405,7 +405,7 @@ def blocks_split(space_shape, block_shape, block_halo=None):
 
         Examples:
 
-            >>> blocks_split(
+            >>> split_blocks(
             ...     (2, 3,), (1, 1,), (1, 1,)
             ... )  #doctest: +NORMALIZE_WHITESPACE
             ([(slice(0, 1, 1), slice(0, 1, 1)),

--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -21,8 +21,8 @@ class TestKenjutsu(unittest.TestCase):
         pass
 
 
-    def test_blocks_split(self):
-        blocks = kenjutsu.blocks_split((2,), (1,))
+    def test_split_blocks(self):
+        blocks = kenjutsu.split_blocks((2,), (1,))
         self.assertEqual(
             blocks,
             ([(slice(0, 1, 1),), (slice(1, 2, 1),)],
@@ -30,7 +30,7 @@ class TestKenjutsu(unittest.TestCase):
              [(slice(0, 1, 1),), (slice(0, 1, 1),)])
         )
 
-        blocks = kenjutsu.blocks_split((2,), (-1,))
+        blocks = kenjutsu.split_blocks((2,), (-1,))
         self.assertEqual(
             blocks,
             ([(slice(0, 2, 1),)],
@@ -38,7 +38,7 @@ class TestKenjutsu(unittest.TestCase):
              [(slice(0, 2, 1),)])
         )
 
-        blocks = kenjutsu.blocks_split((2, 3,), (1, 1,))
+        blocks = kenjutsu.split_blocks((2, 3,), (1, 1,))
         self.assertEqual(
             blocks,
             ([(slice(0, 1, 1), slice(0, 1, 1)),
@@ -61,7 +61,7 @@ class TestKenjutsu(unittest.TestCase):
               (slice(0, 1, 1), slice(0, 1, 1))])
         )
 
-        blocks = kenjutsu.blocks_split((2, 3,), (1, 1,), (0, 0))
+        blocks = kenjutsu.split_blocks((2, 3,), (1, 1,), (0, 0))
         self.assertEqual(
             blocks,
             ([(slice(0, 1, 1), slice(0, 1, 1)),
@@ -84,7 +84,7 @@ class TestKenjutsu(unittest.TestCase):
               (slice(0, 1, 1), slice(0, 1, 1))])
         )
 
-        blocks = kenjutsu.blocks_split((10, 12,), (3, 2,), (4, 3,))
+        blocks = kenjutsu.split_blocks((10, 12,), (3, 2,), (4, 3,))
         self.assertEqual(
             blocks,
             ([(slice(0, 3, 1), slice(0, 2, 1)),


### PR DESCRIPTION
Renames `blocks_split` that was added in PR ( https://github.com/jakirkham/kenjutsu/pull/4 ) to `split_blocks`.
