### PR TITLE
Handle Ellipsis

### DIFF
--- a/kenjutsu/kenjutsu.py
+++ b/kenjutsu/kenjutsu.py
@@ -52,7 +52,9 @@ def reformat_slice(a_slice, a_length=None):
             slice(2, 9, 1)
     """
 
-    if not isinstance(a_slice, slice):
+    if a_slice is Ellipsis:
+        a_slice = slice(None)
+    elif not isinstance(a_slice, slice):
         raise ValueError(
             "Expected a `slice` type. Instead got `%s`." % str(a_slice)
         )

--- a/kenjutsu/kenjutsu.py
+++ b/kenjutsu/kenjutsu.py
@@ -160,22 +160,76 @@ def reformat_slices(slices, lengths=None):
         new_slices = (new_slices,)
 
     new_lengths = lengths
-    if new_lengths is None:
-        new_lengths = [None] * len(new_slices)
-
     try:
-        len(new_lengths)
+        if new_lengths is not None:
+            len(new_lengths)
     except TypeError:
         new_lengths = (new_lengths,)
 
-    if len(new_slices) != len(new_lengths):
-        raise ValueError("There must be an equal number of slices to lengths.")
+    el_idx = None
+    try:
+        el_idx = new_slices.index(Ellipsis)
+    except ValueError:
+        pass
 
-    new_slices = list(new_slices)
-    for i, each_length in enumerate(new_lengths):
-        new_slices[i] = reformat_slice(new_slices[i], each_length)
+    if new_lengths is not None and el_idx is None:
+        if len(new_slices) != len(new_lengths):
+            raise ValueError("Shape must be the same as the number of slices.")
+    elif new_lengths is not None:
+        if (len(new_slices) - 1) > len(new_lengths):
+            raise ValueError(
+                "Shape must be as large or larger than the number of slices"
+                " without the Ellipsis."
+            )
 
-    new_slices = tuple(new_slices)
+    if el_idx is not None:
+        # Break into three cases.
+        #
+        # 1. Before the Ellipsis
+        # 2. The Ellipsis
+        # 3. After the Ellipsis
+        #
+        # Cases 1 and 3 are trivially solved as before.
+        # Case 2 is either a no-op or a bunch of `slice(None)`s.
+        #
+        # The result is a combination of all of these.
+
+        slices_before = new_slices[:el_idx]
+        slices_after = new_slices[el_idx+1:]
+
+        if Ellipsis in slices_before or Ellipsis in slices_after:
+            raise ValueError("Only one Ellipsis is permitted. Found multiple.")
+
+        new_lengths_before = None
+        new_lengths_after = None
+        slice_el = (Ellipsis,)
+        if new_lengths is not None:
+            pos_before = len(slices_before)
+            pos_after = len(new_lengths) - len(slices_after)
+
+            new_lengths_before = new_lengths[:pos_before]
+            new_lengths_after = new_lengths[pos_after:]
+
+            new_lengths_el = new_lengths[pos_before:pos_after]
+            slice_el = reformat_slices(
+                len(new_lengths_el) * (slice(None),),
+                new_lengths_el
+            )
+
+        new_slices = (
+            reformat_slices(slices_before, new_lengths_before) +
+            slice_el +
+            reformat_slices(slices_after, new_lengths_after)
+        )
+    else:
+        if new_lengths is None:
+            new_lengths = [None] * len(new_slices)
+
+        new_slices = list(new_slices)
+        for i, each_length in enumerate(new_lengths):
+            new_slices[i] = reformat_slice(new_slices[i], each_length)
+
+        new_slices = tuple(new_slices)
 
     return(new_slices)
 

--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -80,6 +80,31 @@ class TestKenjutsu(unittest.TestCase):
                             len(range(size)[a_slice])
                         )
 
+            rf_slice = kenjutsu.reformat_slice(Ellipsis)
+            self.assertEqual(
+                range(size)[:],
+                range(size)[rf_slice]
+            )
+
+            rf_slice = kenjutsu.reformat_slice(Ellipsis, size)
+            self.assertEqual(
+                range(size)[:],
+                range(size)[rf_slice]
+            )
+
+            start = rf_slice.start
+            stop = rf_slice.stop
+            step = rf_slice.step
+
+            if step is not None and step < 0 and stop is None:
+                stop = -1
+
+            l = float(stop - start)/float(step)
+            self.assertEqual(
+                int(math.ceil(l)),
+                len(range(size)[:])
+            )
+
 
     def test_reformat_slices(self):
         with self.assertRaises(ValueError) as e:

--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -195,6 +195,11 @@ class TestKenjutsu(unittest.TestCase):
                             len(range(size)[a_slice])
                         )
 
+            self.assertEqual(
+                kenjutsu.len_slice(Ellipsis, size),
+                len(range(size)[:])
+            )
+
 
     def test_len_slices(self):
         with self.assertRaises(kenjutsu.UnknownSliceLengthException):

--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -329,6 +329,12 @@ class TestKenjutsu(unittest.TestCase):
                 slice(None, None, 2)
             ))
 
+        l = kenjutsu.len_slices(Ellipsis, 10)
+        self.assertEqual(
+            l,
+            (10,)
+        )
+
         l = kenjutsu.len_slices(slice(None), 10)
         self.assertEqual(
             l,
@@ -353,6 +359,67 @@ class TestKenjutsu(unittest.TestCase):
         self.assertEqual(
             l,
             (10, 10, 5, 10)
+        )
+
+        l = kenjutsu.len_slices(
+            Ellipsis,
+            (2, 3, 4, 5)
+        )
+        self.assertEqual(
+            l,
+            (2, 3, 4, 5)
+        )
+
+        l = kenjutsu.len_slices(
+            (
+                Ellipsis,
+                slice(0, 1)
+            ),
+            (2, 3, 4, 5)
+        )
+        self.assertEqual(
+            l,
+            (2, 3, 4, 1)
+        )
+
+        l = kenjutsu.len_slices(
+            (
+                slice(0, 1),
+                Ellipsis
+            ),
+            (2, 3, 4, 5)
+        )
+        self.assertEqual(
+            l,
+            (1, 3, 4, 5)
+        )
+
+        l = kenjutsu.len_slices(
+            (
+                slice(0, 1),
+                Ellipsis,
+                slice(0, 1)
+            ),
+            (2, 3, 4, 5)
+        )
+        self.assertEqual(
+            l,
+            (1, 3, 4, 1)
+        )
+
+        l = kenjutsu.len_slices(
+            (
+                slice(0, 1),
+                Ellipsis,
+                slice(0, 1),
+                slice(0, 1),
+                slice(0, 1)
+            ),
+            (2, 3, 4, 5)
+        )
+        self.assertEqual(
+            l,
+            (1, 1, 1, 1)
         )
 
 

--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -112,7 +112,28 @@ class TestKenjutsu(unittest.TestCase):
 
         self.assertEqual(
             str(e.exception),
-            "There must be an equal number of slices to lengths."
+            "Shape must be the same as the number of slices."
+        )
+
+        with self.assertRaises(ValueError) as e:
+            kenjutsu.reformat_slices(
+                (slice(None), slice(None), Ellipsis), (1,)
+            )
+
+        self.assertEqual(
+            str(e.exception),
+            "Shape must be as large or larger than the number of slices"
+            " without the Ellipsis."
+        )
+
+        with self.assertRaises(ValueError) as e:
+            kenjutsu.reformat_slices(
+                (Ellipsis, Ellipsis), (1,)
+            )
+
+        self.assertEqual(
+            str(e.exception),
+            "Only one Ellipsis is permitted. Found multiple."
         )
 
         rf_slice = kenjutsu.reformat_slices(slice(None))
@@ -125,6 +146,18 @@ class TestKenjutsu(unittest.TestCase):
         self.assertEqual(
             rf_slice,
             (slice(0, None, 1),)
+        )
+
+        rf_slice = kenjutsu.reformat_slices(Ellipsis)
+        self.assertEqual(
+            rf_slice,
+            (Ellipsis,)
+        )
+
+        rf_slice = kenjutsu.reformat_slices(Ellipsis, 10)
+        self.assertEqual(
+            rf_slice,
+            (slice(0, 10, 1),)
         )
 
         rf_slice = kenjutsu.reformat_slices(slice(None), 10)
@@ -172,6 +205,92 @@ class TestKenjutsu(unittest.TestCase):
                 slice(3, 13, 1),
                 slice(0, 5, 1),
                 slice(0, 20, 2)
+            )
+        )
+
+        rf_slice = kenjutsu.reformat_slices(
+            Ellipsis,
+            (2, 3, 4, 5)
+        )
+        self.assertEqual(
+            rf_slice,
+            (
+                slice(0, 2, 1),
+                slice(0, 3, 1),
+                slice(0, 4, 1),
+                slice(0, 5, 1)
+            )
+        )
+
+        rf_slice = kenjutsu.reformat_slices(
+            (
+                Ellipsis,
+                slice(0, 1)
+            ),
+            (2, 3, 4, 5)
+        )
+        self.assertEqual(
+            rf_slice,
+            (
+                slice(0, 2, 1),
+                slice(0, 3, 1),
+                slice(0, 4, 1),
+                slice(0, 1, 1)
+            )
+        )
+
+        rf_slice = kenjutsu.reformat_slices(
+            (
+                slice(0, 1),
+                Ellipsis
+            ),
+            (2, 3, 4, 5)
+        )
+        self.assertEqual(
+            rf_slice,
+            (
+                slice(0, 1, 1),
+                slice(0, 3, 1),
+                slice(0, 4, 1),
+                slice(0, 5, 1)
+            )
+        )
+
+        rf_slice = kenjutsu.reformat_slices(
+            (
+                slice(0, 1),
+                Ellipsis,
+                slice(0, 1)
+            ),
+            (2, 3, 4, 5)
+        )
+        self.assertEqual(
+            rf_slice,
+            (
+                slice(0, 1, 1),
+                slice(0, 3, 1),
+                slice(0, 4, 1),
+                slice(0, 1, 1)
+            )
+        )
+
+        rf_slice = kenjutsu.reformat_slices(
+            (
+                slice(0, 1),
+                Ellipsis,
+                slice(0, 1),
+                slice(0, 1),
+                slice(0, 1)
+            ),
+            (2, 3, 4, 5)
+        )
+        self.assertEqual(
+            rf_slice,
+            (
+                slice(0, 1, 1),
+                slice(0, 1, 1),
+                slice(0, 1, 1),
+                slice(0, 1, 1)
             )
         )
 


### PR DESCRIPTION
Adds some code to allow for handling and properly formatting slices with an `Ellipsis` in them. Does not support more than one `Ellipsis` as this is ambiguous.