### PR TITLE
Use test suite

### DIFF
--- a/kenjutsu/kenjutsu.py
+++ b/kenjutsu/kenjutsu.py
@@ -44,77 +44,12 @@ def reformat_slice(a_slice, a_length=None):
                                    possible.
 
         Examples:
-            >>> reformat_slice(slice(None))
-            slice(0, None, 1)
 
-            >>> reformat_slice(slice(None), 10)
-            slice(0, 10, 1)
-
-            >>> reformat_slice(slice(2, None))
-            slice(2, None, 1)
-
-            >>> reformat_slice(slice(2, None), 10)
-            slice(2, 10, 1)
-
-            >>> reformat_slice(slice(2, None, None))
-            slice(2, None, 1)
-
-            >>> reformat_slice(slice(2, None, None), 10)
-            slice(2, 10, 1)
+            >>> reformat_slice(slice(2, -1, None))
+            slice(2, -1, 1)
 
             >>> reformat_slice(slice(2, -1, None), 10)
             slice(2, 9, 1)
-
-            >>> range(10)[reformat_slice(slice(None))] == range(10)[:]
-            True
-
-            >>> range(10)[reformat_slice(slice(2, None))] == range(10)[2:]
-            True
-
-            >>> range(10)[reformat_slice(slice(2, 6))] == range(10)[2:6]
-            True
-
-            >>> range(10)[reformat_slice(slice(2, 6, 3))] == range(10)[2:6:3]
-            True
-
-            >>> range(10)[reformat_slice(slice(2, None, 3))] == range(10)[2::3]
-            True
-
-            >>> range(10)[reformat_slice(slice(None), 10)] == range(10)[:]
-            True
-
-            >>> range(10)[reformat_slice(slice(2, None), 10)] == range(10)[2:]
-            True
-
-            >>> range(10)[reformat_slice(slice(2, 6), 10)] == range(10)[2:6]
-            True
-
-            >>> range(10)[reformat_slice(slice(2, 6, 3), 10)] == range(10)[2:6:3]
-            True
-
-            >>> range(10)[reformat_slice(slice(2, None, 3), 10)] == range(10)[2::3]
-            True
-
-            >>> range(10)[reformat_slice(slice(2, -6, 3), 10)] == range(10)[2:-6:3]
-            True
-
-            >>> range(10)[reformat_slice(slice(2, -1), 10)] == range(10)[2:-1]
-            True
-
-            >>> range(10)[reformat_slice(slice(2, 20), 10)] == range(10)[2:20]
-            True
-
-            >>> range(10)[reformat_slice(slice(2, -20), 10)] == range(10)[2:-20]
-            True
-
-            >>> range(10)[reformat_slice(slice(20, -1), 10)] == range(10)[20:-1]
-            True
-
-            >>> range(10)[reformat_slice(slice(-20, -1), 10)] == range(10)[-20:-1]
-            True
-
-            >>> range(10)[reformat_slice(slice(-5, -1), 10)] == range(10)[-5:-1]
-            True
     """
 
     assert (a_slice is not None), "err"

--- a/kenjutsu/kenjutsu.py
+++ b/kenjutsu/kenjutsu.py
@@ -136,20 +136,6 @@ def reformat_slices(slices, lengths=None):
 
         Examples:
 
-            >>> reformat_slices(slice(None))
-            (slice(0, None, 1),)
-
-            >>> reformat_slices((slice(None),))
-            (slice(0, None, 1),)
-
-            >>> reformat_slices((
-            ...     slice(None),
-            ...     slice(3, None),
-            ...     slice(None, 5),
-            ...     slice(None, None, 2)
-            ... ))
-            (slice(0, None, 1), slice(3, None, 1), slice(0, 5, 1), slice(0, None, 2))
-
             >>> reformat_slices(
             ...     (
             ...         slice(None),

--- a/kenjutsu/kenjutsu.py
+++ b/kenjutsu/kenjutsu.py
@@ -238,14 +238,6 @@ def len_slices(slices, lengths=None):
                                          values filled if possible.
 
         Examples:
-            >>> len_slices((
-            ...     slice(None),
-            ...     slice(3, None),
-            ...     slice(None, 5),
-            ...     slice(None, None, 2)
-            ... )) #doctest: +IGNORE_EXCEPTION_DETAIL
-            Traceback (most recent call last):
-            UnknownSliceLengthException: Cannot determine slice length without a defined end point. The reformatted slice was slice(0, None, 1).
 
             >>> len_slices(
             ...     (

--- a/kenjutsu/kenjutsu.py
+++ b/kenjutsu/kenjutsu.py
@@ -201,42 +201,12 @@ def len_slice(a_slice, a_length=None):
                                    possible.
 
         Examples:
-            >>> len_slice(slice(None)) #doctest: +IGNORE_EXCEPTION_DETAIL
-            Traceback (most recent call last):
-            UnknownSliceLengthException: Cannot determine slice length without a defined end point. The reformatted slice was slice(0, None, 1).
-
-            >>> len_slice(slice(None), 10)
-            10
-
-            >>> len_slice(slice(None), 10) == len(range(10)[:])
-            True
 
             >>> len_slice(slice(2, None), 10)
             8
 
-            >>> len_slice(slice(2, None), 10) == len(range(10)[2:])
-            True
-
-            >>> len_slice(slice(2, None, None), 10)
-            8
-
-            >>> len_slice(slice(2, None, None), 10) == len(range(10)[2:])
-            True
-
             >>> len_slice(slice(2, 6))
             4
-
-            >>> len_slice(slice(2, 6), 1000)
-            4
-
-            >>> len_slice(slice(2, 6), 10) == len(range(10)[2:6])
-            True
-
-            >>> len_slice(slice(2, 6, 3))
-            2
-
-            >>> len_slice(slice(2, 6, 3), 10) == len(range(10)[2:6:3])
-            True
     """
 
     new_slice = reformat_slice(a_slice, a_length)

--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -272,6 +272,47 @@ class TestKenjutsu(unittest.TestCase):
         )
 
 
+    def test_len_slice(self):
+        with self.assertRaises(kenjutsu.UnknownSliceLengthException):
+            kenjutsu.len_slice(slice(None))
+
+        l = kenjutsu.len_slice(slice(None), 10)
+        self.assertEqual(l, 10)
+
+        l = kenjutsu.len_slice(slice(None), 10)
+        self.assertEqual(l, len(range(10)[:]))
+
+        l = kenjutsu.len_slice(slice(2, None), 10)
+        self.assertEqual(l, 8)
+
+        l = kenjutsu.len_slice(slice(2, None), 10)
+        self.assertEqual(l, len(range(10)[2:]))
+
+        l = kenjutsu.len_slice(slice(2, None, None), 10)
+        self.assertEqual(l, 8)
+
+        l = kenjutsu.len_slice(slice(2, None, None), 10)
+        self.assertEqual(l, len(range(10)[2:]))
+
+        l = kenjutsu.len_slice(slice(2, 6))
+        self.assertEqual(l, 4)
+
+        l = kenjutsu.len_slice(slice(2, 6), 10)
+        self.assertEqual(l, 4)
+
+        l = kenjutsu.len_slice(slice(2, 6), 1000)
+        self.assertEqual(l, 4)
+
+        l = kenjutsu.len_slice(slice(2, 6), 10)
+        self.assertEqual(l, len(range(10)[2:6]))
+
+        l = kenjutsu.len_slice(slice(2, 6, 3))
+        self.assertEqual(l, 2)
+
+        l = kenjutsu.len_slice(slice(2, 6, 3))
+        self.assertEqual(l, len(range(10)[2:6:3]))
+
+
     def test_split_blocks(self):
         blocks = kenjutsu.split_blocks((2,), (1,))
         self.assertEqual(

--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -313,6 +313,30 @@ class TestKenjutsu(unittest.TestCase):
         self.assertEqual(l, len(range(10)[2:6:3]))
 
 
+    def test_len_slices(self):
+        with self.assertRaises(kenjutsu.UnknownSliceLengthException):
+            kenjutsu.len_slices((
+                slice(None),
+                slice(3, None),
+                slice(None, 5),
+                slice(None, None, 2)
+            ))
+
+        l = kenjutsu.len_slices(
+            (
+                slice(None),
+                slice(3, None),
+                slice(None, 5),
+                slice(None, None, 2)
+            ),
+            (10, 13, 15, 20)
+        )
+        self.assertEqual(
+            l,
+            (10, 10, 5, 10)
+        )
+
+
     def test_split_blocks(self):
         blocks = kenjutsu.split_blocks((2,), (1,))
         self.assertEqual(

--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -21,6 +21,206 @@ class TestKenjutsu(unittest.TestCase):
         pass
 
 
+    def test_reformat_slice(self):
+        rf_slice = kenjutsu.reformat_slice(slice(None))
+        self.assertEqual(
+            rf_slice,
+            slice(0, None, 1)
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(None), 10)
+        self.assertEqual(
+            rf_slice,
+            slice(0, 10, 1)
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, None))
+        self.assertEqual(
+            rf_slice,
+            slice(2, None, 1)
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, None), 10)
+        self.assertEqual(
+            rf_slice,
+            slice(2, 10, 1)
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, None, None))
+        self.assertEqual(
+            rf_slice,
+            slice(2, None, 1)
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, None, None), 10)
+        self.assertEqual(
+            rf_slice,
+            slice(2, 10, 1)
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, -1), 10)
+        self.assertEqual(
+            rf_slice,
+            slice(2, 9, 1)
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(None))
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[:]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(None, 2))
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[:2]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, None))
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2:]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, 6))
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2:6]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, 6, 3))
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2:6:3]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, -6, 3))
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2:-6:3]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, None, 3))
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2::3]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, -1))
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2:-1]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, 20))
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2:20]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, -20))
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2:-20]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(20, -1))
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[20:-1]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(-20, -1))
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[-20:-1]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(-5, -1))
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[-5:-1]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(None), 10)
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[:]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(None, 2), 10)
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[:2]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, None), 10)
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2:]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, 6), 10)
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2:6]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, 6, 3), 10)
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2:6:3]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, -6, 3), 10)
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2:-6:3]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, None, 3), 10)
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2::3]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, -1), 10)
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2:-1]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, 20), 10)
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2:20]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(2, -20), 10)
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[2:-20]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(20, -1), 10)
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[20:-1]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(-20, -1), 10)
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[-20:-1]
+        )
+
+        rf_slice = kenjutsu.reformat_slice(slice(-5, -1), 10)
+        self.assertEqual(
+            range(10)[rf_slice],
+            range(10)[-5:-1]
+        )
+
+
     def test_split_blocks(self):
         blocks = kenjutsu.split_blocks((2,), (1,))
         self.assertEqual(

--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -221,6 +221,57 @@ class TestKenjutsu(unittest.TestCase):
         )
 
 
+    def test_reformat_slices(self):
+        rf_slice = kenjutsu.reformat_slices(slice(None))
+        self.assertEqual(
+            rf_slice,
+            (slice(0, None, 1),)
+        )
+
+
+        rf_slice = kenjutsu.reformat_slices((slice(None),))
+        self.assertEqual(
+            rf_slice,
+            (slice(0, None, 1),)
+        )
+
+
+        rf_slice = kenjutsu.reformat_slices((
+            slice(None),
+            slice(3, None),
+            slice(None, 5),
+            slice(None, None, 2)
+        ))
+        self.assertEqual(
+            rf_slice,
+            (
+                slice(0, None, 1),
+                slice(3, None, 1),
+                slice(0, 5, 1),
+                slice(0, None, 2)
+            )
+        )
+
+        rf_slice = kenjutsu.reformat_slices(
+            (
+                slice(None),
+                slice(3, None),
+                slice(None, 5),
+                slice(None, None, 2)
+            ),
+            (10, 13, 15, 20)
+        )
+        self.assertEqual(
+            rf_slice,
+            (
+                slice(0, 10, 1),
+                slice(3, 13, 1),
+                slice(0, 5, 1),
+                slice(0, 20, 2)
+            )
+        )
+
+
     def test_split_blocks(self):
         blocks = kenjutsu.split_blocks((2,), (1,))
         self.assertEqual(


### PR DESCRIPTION
Adds all of the existing doctests to a separate test suite. Also cuts down the number of doctests to provide merely a few demonstrative examples. Should make the docs a little easier to follow without losing test coverage.