### PR TITLE
Full test coverage of reformat_slices

### DIFF
--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -228,13 +228,24 @@ class TestKenjutsu(unittest.TestCase):
             (slice(0, None, 1),)
         )
 
-
         rf_slice = kenjutsu.reformat_slices((slice(None),))
         self.assertEqual(
             rf_slice,
             (slice(0, None, 1),)
         )
 
+        rf_slice = kenjutsu.reformat_slices(slice(None), 10)
+        self.assertEqual(
+            rf_slice,
+            (slice(0, 10, 1),)
+        )
+
+
+        rf_slice = kenjutsu.reformat_slices((slice(None),), 10)
+        self.assertEqual(
+            rf_slice,
+            (slice(0, 10, 1),)
+        )
 
         rf_slice = kenjutsu.reformat_slices((
             slice(None),


### PR DESCRIPTION
Adds a couple more tests to cover a few uncovered cases in the `reformat_slices` function. Namely the case where the lengths are not in some kind of `Sequence` derivative instance.