### PR TITLE
Fix out-of-bounds handling in reformat_slice

### DIFF
--- a/kenjutsu/kenjutsu.py
+++ b/kenjutsu/kenjutsu.py
@@ -88,17 +88,19 @@ def reformat_slice(a_slice, a_length=None):
         if step > 0:
             if (start > a_length) or (stop < -a_length):
                 start = stop = 0
-            elif start < -a_length:
-                start = 0
-            elif stop > a_length:
-                stop = a_length
+            else:
+                if start < -a_length:
+                    start = 0
+                if stop > a_length:
+                    stop = a_length
         elif step < 0:
             if (start < -a_length) or (stop >= (a_length - 1)):
                 start = stop = 0
-            elif start >= a_length:
-                start = a_length - 1
-            elif stop < -a_length:
-                stop = None
+            else:
+                if start >= a_length:
+                    start = a_length - 1
+                if stop < -a_length:
+                    stop = None
 
     # Catch some known empty slices.
     if (step > 0) and (stop == 0):


### PR DESCRIPTION
There was a bug in PR ( https://github.com/jakirkham/kenjutsu/pull/15 ), which this tries to fix. There were a couple of out-of-bounds cases with start and stop where they did not effect each other. However, they were part of an `if/elif` branch statement anyways. Even though both statements could be true and executed separately, executing one was blocking the other. This patch fixes it so that they both can be true and acted upon in spite of the other case.