### PR TITLE
Simplify len_slice tests

### DIFF
--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -142,7 +142,7 @@ class TestKenjutsu(unittest.TestCase):
 
                         l = kenjutsu.len_slice(a_slice, size)
                         self.assertEqual(
-                            int(math.ceil(l)),
+                            l,
                             len(range(size)[a_slice])
                         )
 


### PR DESCRIPTION
Drop unnecessary operations in `len_slice` tests