### PR TITLE
More tests for len_slices

### DIFF
--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -180,6 +180,18 @@ class TestKenjutsu(unittest.TestCase):
                 slice(None, None, 2)
             ))
 
+        l = kenjutsu.len_slices(slice(None), 10)
+        self.assertEqual(
+            l,
+            (10,)
+        )
+
+        l = kenjutsu.len_slices((slice(None),), 10)
+        self.assertEqual(
+            l,
+            (10,)
+        )
+
         l = kenjutsu.len_slices(
             (
                 slice(None),


### PR DESCRIPTION
Borrows some tests from `reformat_slices` and adapt them for `len_slices`.