### PR TITLE
Maintain original arguments to reformat_slice (Pt. 3)

### DIFF
--- a/kenjutsu/kenjutsu.py
+++ b/kenjutsu/kenjutsu.py
@@ -57,7 +57,7 @@ def reformat_slice(a_slice, a_length=None):
         new_slice = slice(None)
     elif not isinstance(a_slice, slice):
         raise ValueError(
-            "Expected a `slice` type. Instead got `%s`." % str(new_slice)
+            "Expected a `slice` type. Instead got `%s`." % str(a_slice)
         )
 
     if new_slice.step == 0:


### PR DESCRIPTION
This makes another tweak on PR ( https://github.com/jakirkham/kenjutsu/pull/27 ) that was missed in PR ( https://github.com/jakirkham/kenjutsu/pull/28 ) to ensure arguments to `reformat_slice` are not mutated.