### PR TITLE
Handle an empty tuple

### DIFF
--- a/kenjutsu/kenjutsu.py
+++ b/kenjutsu/kenjutsu.py
@@ -53,7 +53,7 @@ def reformat_slice(a_slice, a_length=None):
     """
 
     new_slice = a_slice
-    if new_slice is Ellipsis:
+    if (new_slice is Ellipsis) or (new_slice == tuple()):
         new_slice = slice(None)
     elif not isinstance(a_slice, slice):
         raise ValueError(

--- a/kenjutsu/kenjutsu.py
+++ b/kenjutsu/kenjutsu.py
@@ -155,6 +155,9 @@ def reformat_slices(slices, lengths=None):
     """
 
     new_slices = slices
+    if new_slices == tuple():
+        new_slices = Ellipsis
+
     try:
         len(new_slices)
     except TypeError:
@@ -213,16 +216,18 @@ def reformat_slices(slices, lengths=None):
 
             new_lengths_el = new_lengths[pos_before:pos_after]
             slice_el = len(new_lengths_el) * (slice(None),)
-            slice_el = reformat_slices(
-                slice_el,
-                new_lengths_el
-            )
+            if slice_el:
+                slice_el = reformat_slices(
+                    slice_el,
+                    new_lengths_el
+                )
 
-        new_slices = (
-            reformat_slices(slices_before, new_lengths_before) +
-            slice_el +
-            reformat_slices(slices_after, new_lengths_after)
-        )
+        if slices_before:
+            slices_before = reformat_slices(slices_before, new_lengths_before)
+        if slices_after:
+            slices_after = reformat_slices(slices_after, new_lengths_after)
+
+        new_slices = slices_before + slice_el + slices_after
     else:
         if new_lengths is None:
             new_lengths = [None] * len(new_slices)

--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -172,6 +172,18 @@ class TestKenjutsu(unittest.TestCase):
             (slice(0, 10, 1),)
         )
 
+        rf_slice = kenjutsu.reformat_slices(tuple())
+        self.assertEqual(
+            rf_slice,
+            (Ellipsis,)
+        )
+
+        rf_slice = kenjutsu.reformat_slices(tuple(), 10)
+        self.assertEqual(
+            rf_slice,
+            (slice(0, 10, 1),)
+        )
+
         rf_slice = kenjutsu.reformat_slices(slice(None), 10)
         self.assertEqual(
             rf_slice,

--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -343,6 +343,11 @@ class TestKenjutsu(unittest.TestCase):
                 len(range(size)[:])
             )
 
+            self.assertEqual(
+                kenjutsu.len_slice(tuple(), size),
+                len(range(size)[:])
+            )
+
 
     def test_len_slices(self):
         with self.assertRaises(kenjutsu.UnknownSliceLengthException):

--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -364,6 +364,12 @@ class TestKenjutsu(unittest.TestCase):
             (10,)
         )
 
+        l = kenjutsu.len_slices(tuple(), 10)
+        self.assertEqual(
+            l,
+            (10,)
+        )
+
         l = kenjutsu.len_slices(slice(None), 10)
         self.assertEqual(
             l,

--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -92,6 +92,18 @@ class TestKenjutsu(unittest.TestCase):
                 range(size)[rf_slice]
             )
 
+            rf_slice = kenjutsu.reformat_slice(tuple())
+            self.assertEqual(
+                range(size)[:],
+                range(size)[rf_slice]
+            )
+
+            rf_slice = kenjutsu.reformat_slice(tuple(), size)
+            self.assertEqual(
+                range(size)[:],
+                range(size)[rf_slice]
+            )
+
             start = rf_slice.start
             stop = rf_slice.stop
             step = rf_slice.step


### PR DESCRIPTION
An empty `tuple` behaves the same as an `Ellipsis` AFAICT. So this goes ahead and handles the empty `tuple` the same way as an `Ellipsis`. This means `reformat_slices(tuple())` will return `(Ellipsis,)`. Though `reformat_slice(tuple())` will return `(slice(0, None, 1),)`. However, if a real shape is provided, these will of course be converted to `slice`(s).