### PR TITLE
Improve empty slice handling

### DIFF
--- a/kenjutsu/kenjutsu.py
+++ b/kenjutsu/kenjutsu.py
@@ -120,6 +120,9 @@ def reformat_slice(a_slice, a_length=None):
     elif (step > 0) and (stop == 0):
         start = stop = 0
         step = 1
+    elif (step < 0) and (stop == -1):
+        start = stop = 0
+        step = 1
     elif stop_i and (start >= 0) and (stop >= 0):
         if (step > 0) and (start > stop):
             start = stop = 0

--- a/kenjutsu/kenjutsu.py
+++ b/kenjutsu/kenjutsu.py
@@ -116,13 +116,17 @@ def reformat_slice(a_slice, a_length=None):
     # Catch some known empty slices.
     if stop_i and (start == stop):
         start = stop = 0
+        step = 1
     elif (step > 0) and (stop == 0):
         start = stop = 0
+        step = 1
     elif stop_i and (start >= 0) and (stop >= 0):
         if (step > 0) and (start > stop):
             start = stop = 0
+            step = 1
         elif (step < 0) and (start < stop):
             start = stop = 0
+            step = 1
 
     new_slice = slice(start, stop, step)
 

--- a/kenjutsu/kenjutsu.py
+++ b/kenjutsu/kenjutsu.py
@@ -114,7 +114,9 @@ def reformat_slice(a_slice, a_length=None):
                     stop_i = False
 
     # Catch some known empty slices.
-    if (step > 0) and (stop == 0):
+    if stop_i and (start == stop):
+        start = stop = 0
+    elif (step > 0) and (stop == 0):
         start = stop = 0
     elif stop_i and (start >= 0) and (stop >= 0):
         if (step > 0) and (start > stop):


### PR DESCRIPTION
Improves empty slice handling by catching the case of a slice with the same start and stop value. Also catches another case where the slice may be empty for a certain stop value. Finally sets the step of all empty slices to 1 for uniformity.