### PR TITLE
Use Travis CI master badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ kenjutsu
 .. image:: https://img.shields.io/pypi/v/kenjutsu.svg
         :target: https://pypi.python.org/pypi/kenjutsu
 
-.. image:: https://img.shields.io/travis/jakirkham/kenjutsu.svg
+.. image:: https://img.shields.io/travis/jakirkham/kenjutsu/master.svg
         :target: https://travis-ci.org/jakirkham/kenjutsu
 
 .. image:: https://readthedocs.org/projects/kenjutsu/badge/?version=latest


### PR DESCRIPTION
Was pointing to latest before, which could include branches in development. Hence it was inaccurate reflection of the current build status.