### PR TITLE
Rename divide to blocks

### DIFF
--- a/kenjutsu/blocks.py
+++ b/kenjutsu/blocks.py
@@ -182,8 +182,8 @@ def split_blocks(space_shape, block_shape, block_halo=None):
         trimmed_halos_per_dim.append(a_trimmed_halo)
 
     # Take all combinations of all ranges to get blocks.
-    blocks = list(itertools.product(*ranges_per_dim))
+    orig_blocks = list(itertools.product(*ranges_per_dim))
     haloed_blocks = list(itertools.product(*haloed_ranges_per_dim))
     trimmed_halos = list(itertools.product(*trimmed_halos_per_dim))
 
-    return(blocks, haloed_blocks, trimmed_halos)
+    return(orig_blocks, haloed_blocks, trimmed_halos)

--- a/kenjutsu/core.py
+++ b/kenjutsu/core.py
@@ -25,7 +25,7 @@ __author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
 __date__ = "$Dec 08, 2016 11:35:58 GMT-0500$"
 
 
-import kenjutsu.divide
+import kenjutsu.blocks
 import kenjutsu.format
 import kenjutsu.measure
 
@@ -37,4 +37,4 @@ UnknownSliceLengthException = kenjutsu.measure.UnknownSliceLengthException
 len_slice = kenjutsu.measure.len_slice
 len_slices = kenjutsu.measure.len_slices
 
-split_blocks = kenjutsu.divide.split_blocks
+split_blocks = kenjutsu.blocks.split_blocks

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -6,7 +6,7 @@ import doctest
 import sys
 import unittest
 
-from kenjutsu import divide
+from kenjutsu import blocks
 
 
 try:
@@ -15,20 +15,20 @@ except NameError:
     irange = range
 
 
-# Load doctests from `divide`.
+# Load doctests from `blocks`.
 def load_tests(loader, tests, ignore):
-    tests.addTests(doctest.DocTestSuite(divide))
+    tests.addTests(doctest.DocTestSuite(blocks))
     return tests
 
 
-class TestDivide(unittest.TestCase):
+class TestBlocks(unittest.TestCase):
     def setUp(self):
         pass
 
 
     def test_split_blocks(self):
         with self.assertRaises(ValueError) as e:
-            divide.split_blocks((1,), (1, 2), (1, 2, 3))
+            blocks.split_blocks((1,), (1, 2), (1, 2, 3))
 
         self.assertEqual(
             str(e.exception),
@@ -37,7 +37,7 @@ class TestDivide(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as e:
-            divide.split_blocks((1,), (1, 2))
+            blocks.split_blocks((1,), (1, 2))
 
         self.assertEqual(
             str(e.exception),
@@ -45,25 +45,25 @@ class TestDivide(unittest.TestCase):
             " same."
         )
 
-        blocks = divide.split_blocks((2,), (1,))
+        result = blocks.split_blocks((2,), (1,))
         self.assertEqual(
-            blocks,
+            result,
             ([(slice(0, 1, 1),), (slice(1, 2, 1),)],
              [(slice(0, 1, 1),), (slice(1, 2, 1),)],
              [(slice(0, 1, 1),), (slice(0, 1, 1),)])
         )
 
-        blocks = divide.split_blocks((2,), (-1,))
+        result = blocks.split_blocks((2,), (-1,))
         self.assertEqual(
-            blocks,
+            result,
             ([(slice(0, 2, 1),)],
              [(slice(0, 2, 1),)],
              [(slice(0, 2, 1),)])
         )
 
-        blocks = divide.split_blocks((2, 3,), (1, 1,))
+        result = blocks.split_blocks((2, 3,), (1, 1,))
         self.assertEqual(
-            blocks,
+            result,
             ([(slice(0, 1, 1), slice(0, 1, 1)),
               (slice(0, 1, 1), slice(1, 2, 1)),
               (slice(0, 1, 1), slice(2, 3, 1)),
@@ -84,9 +84,9 @@ class TestDivide(unittest.TestCase):
               (slice(0, 1, 1), slice(0, 1, 1))])
         )
 
-        blocks = divide.split_blocks((2, 3,), (1, 1,), (0, 0))
+        result = blocks.split_blocks((2, 3,), (1, 1,), (0, 0))
         self.assertEqual(
-            blocks,
+            result,
             ([(slice(0, 1, 1), slice(0, 1, 1)),
               (slice(0, 1, 1), slice(1, 2, 1)),
               (slice(0, 1, 1), slice(2, 3, 1)),
@@ -107,9 +107,9 @@ class TestDivide(unittest.TestCase):
               (slice(0, 1, 1), slice(0, 1, 1))])
         )
 
-        blocks = divide.split_blocks((10, 12,), (3, 2,), (4, 3,))
+        result = blocks.split_blocks((10, 12,), (3, 2,), (4, 3,))
         self.assertEqual(
-            blocks,
+            result,
             ([(slice(0, 3, 1), slice(0, 2, 1)),
               (slice(0, 3, 1), slice(2, 4, 1)),
               (slice(0, 3, 1), slice(4, 6, 1)),


### PR DESCRIPTION
Follow-up on PR ( https://github.com/jakirkham/kenjutsu/pull/43 ).

Renames the module `divide` to `blocks`.