### PR TITLE
Catch more unknown length cases

### DIFF
--- a/kenjutsu/measure.py
+++ b/kenjutsu/measure.py
@@ -54,14 +54,21 @@ def len_slice(a_slice, a_length=None):
 
     new_slice_size = 0
     if isinstance(new_slice, slice):
-        if new_slice.stop is None:
-            if new_slice.step > 0:
+        if (new_slice.step > 0 and new_slice.start >= 0 and
+                (new_slice.stop is None or new_slice.stop < 0)):
                 raise UnknownSliceLengthException(
-                    "Cannot determine slice length without a defined end"
+                    "Cannot determine slice length without a defined start"
                     " point. The reformatted slice was %s." % repr(new_slice)
                 )
-            else:
-                new_slice = slice(new_slice.start, -1, new_slice.step)
+        elif (new_slice.step < 0 and new_slice.start < 0 and
+                (new_slice.stop is None or new_slice.stop >= 0)):
+                raise UnknownSliceLengthException(
+                    "Cannot determine slice length without a defined start"
+                    " point. The reformatted slice was %s." % repr(new_slice)
+                )
+
+        if new_slice.step < 0 and new_slice.stop is None:
+            new_slice = slice(new_slice.start, -1, new_slice.step)
 
         new_slice_diff = float(new_slice.stop - new_slice.start)
 

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -36,6 +36,9 @@ class TestMeasure(unittest.TestCase):
         with self.assertRaises(measure.UnknownSliceLengthException):
             measure.len_slice(slice(None))
 
+        with self.assertRaises(measure.UnknownSliceLengthException):
+            measure.len_slice(slice(None, None, -1))
+
         for size in [10, 11, 12]:
             excess = size + 3
             each_range = range(size)


### PR DESCRIPTION
Catches cases of unknown length based on the sign of the step size and values for start and stop that leave things ambiguous (e.g. differing signs). Needs some more testing to cover it.