### PR TITLE
Bump to Sphinx 1.5.1

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -9,6 +9,6 @@ dependencies:
   - flake8==2.6.2
   - coverage==3.7.1
   - python-coveralls=2.5.0
-  - Sphinx==1.4.5
+  - Sphinx==1.5.1
   - cryptography==1.4
   - pyyaml==3.11


### PR DESCRIPTION
This seems to fix some bug caused by the interaction between Sphinx and docutils 0.13.1. The issue caused a build failure on Read The Docs (RTD) as it tried to install the newest docutils even after having it pinned before.

xref: https://github.com/sphinx-doc/sphinx/issues/3212
xref: https://github.com/sphinx-doc/sphinx/pull/3217