### PR TITLE
Add `split_indices`

### DIFF
--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -482,3 +482,70 @@ class TestFormat(unittest.TestCase):
                 slice(0, 1, 1)
             )
         )
+
+
+    def test_split_indices(self):
+        with self.assertRaises(ValueError) as e:
+            format.split_indices(
+                ([0, 1], [0, 1]),
+            )
+
+        self.assertEqual(
+            str(e.exception),
+            "Only one integral sequence supported. Instead got `2`."
+        )
+
+        sp_slice = format.split_indices(
+            (3, Ellipsis, 0, slice(2, 5, 1), -1)
+        )
+        self.assertEqual(
+            sp_slice,
+            [
+                (3, Ellipsis, 0, slice(2, 5, 1), -1)
+            ]
+        )
+
+        sp_slice = format.split_indices(
+            (3, Ellipsis, 0, slice(2, 5, 1), [-1])
+        )
+        self.assertEqual(
+            sp_slice,
+            [
+                (3, Ellipsis, 0, slice(2, 5, 1), slice(-1, -2, -1))
+            ]
+        )
+
+        sp_slice = format.split_indices(
+            (3, Ellipsis, [0], slice(2, 5, 1), -1)
+        )
+        self.assertEqual(
+            sp_slice,
+            [
+                (3, Ellipsis, slice(0, 1, 1), slice(2, 5, 1), -1)
+            ]
+        )
+
+        sp_slice = format.split_indices(
+            (3, Ellipsis, [0, 1, 2], slice(2, 5, 1), -1)
+        )
+        self.assertEqual(
+            sp_slice,
+            [
+                (3, Ellipsis, slice(0, 1, 1), slice(2, 5, 1), -1),
+                (3, Ellipsis, slice(1, 2, 1), slice(2, 5, 1), -1),
+                (3, Ellipsis, slice(2, 3, 1), slice(2, 5, 1), -1)
+            ]
+        )
+
+        sp_slice = format.split_indices(
+            (3, Ellipsis, [2, 0, 1, 2], slice(2, 5, 1), -1)
+        )
+        self.assertEqual(
+            sp_slice,
+            [
+                (3, Ellipsis, slice(2, 3, 1), slice(2, 5, 1), -1),
+                (3, Ellipsis, slice(0, 1, 1), slice(2, 5, 1), -1),
+                (3, Ellipsis, slice(1, 2, 1), slice(2, 5, 1), -1),
+                (3, Ellipsis, slice(2, 3, 1), slice(2, 5, 1), -1)
+            ]
+        )


### PR DESCRIPTION
Closes https://github.com/jakirkham/kenjutsu/pull/52

Adds a utility function, `split_indices`, for splitting up slices with multiple indices into a list of slices each with a single index. This is handy when working with libraries that accept slices that have a single index, but balk when multiple indices are provided. In these cases, one can split up the multiple indices into multiple slices, which can then be iterated over. Construction of the total result is up to user.

Note: This only works on slices that have a single list of indices. Support for multiple lists of indices does not currently exist and will require resolution of issue ( https://github.com/jakirkham/kenjutsu/issues/57 ).