### PR TITLE
Note index and slice failure cases in `index_to_slice`

### DIFF
--- a/kenjutsu/format.py
+++ b/kenjutsu/format.py
@@ -13,7 +13,10 @@ def index_to_slice(index):
         Note:
             A single index behaves differently from a length 1 ``slice``. When
             applying the former one reduces that dimension; whereas, applying
-            the latter results in a singleton dimension being retained.
+            the latter results in a singleton dimension being retained. Also
+            if an index is out of bounds, one gets an ``IndexError``. However,
+            with an out of bounds length 1 ``slice``, one simply doesn't get
+            the requested range.
 
         Args:
             index(int):                  an index to convert to a slice

--- a/kenjutsu/format.py
+++ b/kenjutsu/format.py
@@ -11,7 +11,7 @@ def index_to_slice(index):
         Convert an index to a slice.
 
         Note:
-            A single index behaves differently from a length 1 slice. When
+            A single index behaves differently from a length 1 ``slice``. When
             applying the former one reduces that dimension; whereas, applying
             the latter results in a singleton dimension being retained.
 


### PR DESCRIPTION
As an index and a `slice` fail differently when out of bounds, we add a note to `index_to_slice` to explain that an index that is out of bounds results in an `IndexError`, but a `slice` that is out of bounds will just return an empty segment. This is another important distinction for users to be aware of before using this function.