### PR TITLE
Allow only one integral sequence per slice

### DIFF
--- a/kenjutsu/format.py
+++ b/kenjutsu/format.py
@@ -282,4 +282,13 @@ def reformat_slices(slices, lengths=None):
 
         new_slices = tuple(new_slices)
 
+    n_seqs = sum(map(
+        lambda i: isinstance(i, collections.Sequence), new_slices
+    ))
+    if n_seqs > 1:
+        raise ValueError(
+            "Only one integral sequence supported."
+            " Instead got `%s`." % str(n_seqs)
+        )
+
     return(new_slices)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -298,6 +298,16 @@ class TestFormat(unittest.TestCase):
             "Only one Ellipsis is permitted. Found multiple."
         )
 
+        with self.assertRaises(ValueError) as e:
+            format.reformat_slices(
+                ([0, 1], [0, 1]),
+            )
+
+        self.assertEqual(
+            str(e.exception),
+            "Only one integral sequence supported. Instead got `2`."
+        )
+
         rf_slice = format.reformat_slices(slice(None))
         self.assertEqual(
             rf_slice,


### PR DESCRIPTION
Follow-up to PR ( https://github.com/jakirkham/kenjutsu/pull/38 )

There are a lot of subtle cases when support multiple integral sequences, which we are not currently supporting correctly. So as to avoid potentially providing an incorrect result, simply raise an exception if multiple integral sequences show up in a slices and note that only one is supported in a slice. Hopefully we can fix this and relaxing this constraint in the future.