### PR TITLE
Change some `ValueError`s to `TypeError`s

### DIFF
--- a/kenjutsu/format.py
+++ b/kenjutsu/format.py
@@ -75,7 +75,7 @@ def reformat_slice(a_slice, a_length=None):
         new_slice = index_to_slice(a_slice)
     elif isinstance(a_slice, collections.Sequence):
         if not all(map(lambda i: isinstance(i, numbers.Integral), a_slice)):
-            raise ValueError(
+            raise TypeError(
                 "Arbitrary sequences not permitted."
                 " All elements must be of integral type."
             )
@@ -86,7 +86,7 @@ def reformat_slice(a_slice, a_length=None):
             new_slice.append(reformat_slice(i, a_length))
         return new_slice
     elif not isinstance(a_slice, slice):
-        raise ValueError(
+        raise TypeError(
             "Expected a `slice` type. Instead got `%s`." % str(a_slice)
         )
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -109,7 +109,7 @@ class TestFormat(unittest.TestCase):
 
 
     def test_reformat_slice(self):
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(TypeError) as e:
             format.reformat_slice(None)
 
         self.assertEqual(
@@ -125,7 +125,7 @@ class TestFormat(unittest.TestCase):
             "Slice cannot have a step size of `0`."
         )
 
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(TypeError) as e:
             format.reformat_slice([None])
 
         self.assertEqual(

--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -35,7 +35,7 @@ class TestKenjutsu(unittest.TestCase):
 
 
     def test_reformat_slice(self):
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(TypeError) as e:
             kenjutsu.reformat_slice(None)
 
         self.assertEqual(
@@ -51,7 +51,7 @@ class TestKenjutsu(unittest.TestCase):
             "Slice cannot have a step size of `0`."
         )
 
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(TypeError) as e:
             kenjutsu.reformat_slice([None])
 
         self.assertEqual(


### PR DESCRIPTION
Had some `ValueError`s raised in `reformat_slice`, which really should have been `TypeError`s. The two cases in particular were unsupported general type or sequence that contained unsupported elements like non-integers. This converts them to `TypeError`s instead.