### PR TITLE
Update type error message in `reformat_slice`

### DIFF
--- a/kenjutsu/format.py
+++ b/kenjutsu/format.py
@@ -87,7 +87,8 @@ def reformat_slice(a_slice, a_length=None):
         return new_slice
     elif not isinstance(a_slice, slice):
         raise TypeError(
-            "Expected a `slice` type. Instead got `%s`." % str(a_slice)
+            "Expected an index acceptable type."
+            " Instead got, `%s`." % str(a_slice)
         )
 
     if new_slice.step == 0:

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -114,7 +114,8 @@ class TestFormat(unittest.TestCase):
 
         self.assertEqual(
             str(e.exception),
-            "Expected a `slice` type. Instead got `None`."
+            "Expected an index acceptable type."
+            " Instead got, `None`."
         )
 
         with self.assertRaises(ValueError) as e:

--- a/tests/test_kenjutsu.py
+++ b/tests/test_kenjutsu.py
@@ -40,7 +40,8 @@ class TestKenjutsu(unittest.TestCase):
 
         self.assertEqual(
             str(e.exception),
-            "Expected a `slice` type. Instead got `None`."
+            "Expected an index acceptable type."
+            " Instead got, `None`."
         )
 
         with self.assertRaises(ValueError) as e:


### PR DESCRIPTION
The type error message provided by `reformat_slice` implied a `slice` must be provided. In reality, a variety of objects are accepted. So it makes sense to update this message to be more accurate and update associated tests to reflect that.