### PR TITLE
Assertions about shapes for `split_blocks`

### DIFF
--- a/kenjutsu/blocks.py
+++ b/kenjutsu/blocks.py
@@ -103,6 +103,12 @@ def split_blocks(space_shape, block_shape, block_halo=None):
             "Instead got: %s." % str(block_shape)
         )
 
+    if not all(imap(lambda e: e >= 0, block_halo)):
+        raise ValueError(
+            "Shape of the halo must all be positive semidefinite."
+            "Instead got: %s." % str(block_halo)
+        )
+
     vec_add = lambda a, b: imap(operator.add, a, b)
     vec_sub = lambda a, b: imap(operator.sub, a, b)
 

--- a/kenjutsu/blocks.py
+++ b/kenjutsu/blocks.py
@@ -91,6 +91,12 @@ def split_blocks(space_shape, block_shape, block_halo=None):
         for i in irange(len(space_shape)):
             block_halo += (0,)
 
+    if not all(imap(lambda e: e > 0, space_shape)):
+        raise ValueError(
+            "Shape of the space must all be positive definite."
+            "Instead got: %s." % str(space_shape)
+        )
+
     vec_add = lambda a, b: imap(operator.add, a, b)
     vec_sub = lambda a, b: imap(operator.sub, a, b)
 

--- a/kenjutsu/blocks.py
+++ b/kenjutsu/blocks.py
@@ -97,6 +97,12 @@ def split_blocks(space_shape, block_shape, block_halo=None):
             "Instead got: %s." % str(space_shape)
         )
 
+    if not all(imap(lambda e: e > 0 or e == -1, block_shape)):
+        raise ValueError(
+            "Shape of the blocks must all be positive or -1."
+            "Instead got: %s." % str(block_shape)
+        )
+
     vec_add = lambda a, b: imap(operator.add, a, b)
     vec_sub = lambda a, b: imap(operator.sub, a, b)
 

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -45,6 +45,15 @@ class TestBlocks(unittest.TestCase):
             " same."
         )
 
+        with self.assertRaises(ValueError) as e:
+            blocks.split_blocks((1, 0), (1, -1))
+
+        self.assertEqual(
+            str(e.exception),
+            "Shape of the space must all be positive definite."
+            "Instead got: (1, 0)."
+        )
+
         result = blocks.split_blocks((2,), (1,))
         self.assertEqual(
             result,

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -72,6 +72,15 @@ class TestBlocks(unittest.TestCase):
             "Instead got: (1, -2)."
         )
 
+        with self.assertRaises(ValueError) as e:
+            blocks.split_blocks((1, 2), (1, 1), (0, -1))
+
+        self.assertEqual(
+            str(e.exception),
+            "Shape of the halo must all be positive semidefinite."
+            "Instead got: (0, -1)."
+        )
+
         result = blocks.split_blocks((2,), (1,))
         self.assertEqual(
             result,

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -54,6 +54,24 @@ class TestBlocks(unittest.TestCase):
             "Instead got: (1, 0)."
         )
 
+        with self.assertRaises(ValueError) as e:
+            blocks.split_blocks((1, 2), (1, 0))
+
+        self.assertEqual(
+            str(e.exception),
+            "Shape of the blocks must all be positive or -1."
+            "Instead got: (1, 0)."
+        )
+
+        with self.assertRaises(ValueError) as e:
+            blocks.split_blocks((1, 2), (1, -2))
+
+        self.assertEqual(
+            str(e.exception),
+            "Shape of the blocks must all be positive or -1."
+            "Instead got: (1, -2)."
+        )
+
         result = blocks.split_blocks((2,), (1,))
         self.assertEqual(
             result,


### PR DESCRIPTION
Adds assertions about the lower bound of acceptable values for each shape. This should avoid some potentially strange results if values that don't match these are provided.